### PR TITLE
Use 1-based mark offsets

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub struct Mark {
 
 impl std::fmt::Display for Mark {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "line {} column {}", self.line, self.column)
+        write!(f, "line {} column {}", self.line + 1, self.column + 1)
     }
 }
 

--- a/tests/test_mark_display.rs
+++ b/tests/test_mark_display.rs
@@ -1,0 +1,46 @@
+use libyaml_safer::Parser;
+
+/// Test that errors at the very beginning display as line 1 column 1.
+#[test]
+fn first_position() {
+    const INVALID_YAML: &str = "\t";
+
+    let mut parser = Parser::new();
+    let mut input = INVALID_YAML.as_bytes();
+    parser.set_input_string(&mut input);
+
+    let result = parser.collect::<Result<Vec<_>, _>>();
+
+    assert!(result.is_err(), "Expected parsing to fail for invalid YAML");
+    let err = result.unwrap_err();
+
+    let mark = err.problem_mark().unwrap();
+    let mark_str = mark.to_string();
+    eprintln!("Problem mark: {}", mark_str);
+
+    assert_eq!(mark_str, "line 1 column 1");
+}
+
+/// Test that error messages display 1-based line and column numbers.
+///
+/// This YAML has a missing closing quote (from test CQ3W).
+#[test]
+fn multiline_error() {
+    const INVALID_YAML: &str = "---\nkey: \"missing closing quote";
+
+    let mut parser = Parser::new();
+    let mut input = INVALID_YAML.as_bytes();
+    parser.set_input_string(&mut input);
+
+    let result = parser.collect::<Result<Vec<_>, _>>();
+
+    assert!(result.is_err(), "Expected parsing to fail for invalid YAML");
+    let err = result.unwrap_err();
+
+    // Verify that the mark can be retrieved and displays correctly
+    let mark = err.problem_mark().unwrap();
+    let mark_str = mark.to_string();
+    eprintln!("Problem mark: {}", mark_str);
+
+    assert_eq!(mark_str, "line 2 column 28");
+}


### PR DESCRIPTION
Line 0 and column 0 in error messages is not great UX, and doesnt match what happens in `unsafe-libyaml`