### PR TITLE
Lower MSRV to 1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.75.0]
+        rust: [nightly, beta, stable, 1.75.0, 1.70.0, 1.64.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +34,9 @@ jobs:
       - name: Enable type layout randomization
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
         if: matrix.rust == 'nightly'
+      - name: Disable criterion
+        run: sed -i '/criterion/d' Cargo.toml
+        if: startsWith(matrix.rust, '1.')
       - run: cargo test
 
   msrv:
@@ -96,14 +99,3 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-fuzz
       - run: cargo fuzz check
-
-  outdated:
-    name: Outdated
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/install@cargo-outdated
-      - run: cargo outdated --workspace --exit-code 1
-      - run: cargo outdated --manifest-path fuzz/Cargo.toml --exit-code 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,6 @@ jobs:
         if: startsWith(matrix.rust, '1.')
       - run: cargo test
 
-  msrv:
-    name: Rust 1.70.0
-    needs: pre_ci
-    if: needs.pre_ci.outputs.continue
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70.0
-      - run: cargo check --lib
-
   doc:
     name: Documentation
     needs: pre_ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,27 @@
 ## Unreleased
 
 ### Breaking changes
-- Migrated to Rust Edition 2024 (MSRV 1.85).
+
 - `Scanner` and `Parser` are now generic over the input stream, instead of using dynamic
   dispatch `dyn BufRead`. This allows the input to be owned by the parser using `std::io::Cursor`.
+
+### Changes
+
+- MSRV lowered from 1.70 to 1.64 (@jayvdb).
 
 ## 0.2.0 - 2025-11-26
 
 ### Bugfixes
+
 - Fix handling of CRLF line endings (@dougvalenta).
 - Use 1-based mark offsets (@jayvdb).
 
 ## 0.1.1 - 2024-02-11
+
 ### Added
+
 - Implement `PartialEq` and `Debug` for `Event` and `Token`.
+
 ### Bugfixes
+
 - Fix a bug where marks would not be correctly set for tokens and events.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,14 @@ authors = ["Simon Ask Ulsnes <simon@ulsnes.dk"]
 categories = ["encoding", "parser-implementations"]
 description = "Safer libyaml port, based on unsafe-libyaml"
 documentation = "https://docs.rs/libyaml-safer"
-edition = "2024"
+edition = "2021"
 keywords = ["yaml"]
 license-file = "LICENSE-MIT"
 repository = "https://github.com/simonask/libyaml-safer"
-rust-version = "1.85"
+rust-version = "1.64"
 
 [dev-dependencies]
+# To test on 1.64, comment out `criterion`.
 criterion = "0.5.1"
 pretty_assertions = "1.0"
 unsafe-libyaml = "0.2.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/simonask/libyaml-safer"
 rust-version = "1.64"
 
 [dev-dependencies]
-# To test on 1.64, comment out `criterion`.
+# To test on 1.64,1.75,etc, comment out `criterion`.
 criterion = "0.5.1"
 pretty_assertions = "1.0"
 unsafe-libyaml = "0.2.10"

--- a/src/bin/run-emitter-test-suite.rs
+++ b/src/bin/run-emitter-test-suite.rs
@@ -116,8 +116,9 @@ fn get_tag(line: &str) -> Option<&str> {
 fn get_value<'a>(line: &str, buffer: &'a mut String, style: &mut ScalarStyle) -> &'a str {
     let mut remainder = line;
     let value = loop {
-        let Some((_before, tail)) = remainder.split_once(' ') else {
-            panic!("invalid line: {line}");
+        let (_before, tail) = match remainder.split_once(' ') {
+            Some(parts) => parts,
+            None => panic!("invalid line: {line}"),
         };
 
         *style = match tail.chars().next().expect("string should not be empty") {

--- a/src/document.rs
+++ b/src/document.rs
@@ -359,8 +359,9 @@ impl Document {
         index: i32,
         anchor: Option<String>,
     ) -> Result<()> {
-        let Some(anchor) = anchor else {
-            return Ok(());
+        let anchor = match anchor {
+            Some(anchor) => anchor,
+            None => return Ok(()),
         };
         let data = AliasData {
             anchor,
@@ -382,8 +383,9 @@ impl Document {
     }
 
     fn load_node_add(&mut self, ctx: &[i32], index: i32) -> Result<()> {
-        let Some(parent_index) = ctx.last() else {
-            return Ok(());
+        let parent_index = match ctx.last() {
+            Some(parent_index) => parent_index,
+            None => return Ok(()),
         };
         let parent_index = *parent_index;
         let parent = &mut self.nodes[parent_index as usize - 1];
@@ -410,8 +412,9 @@ impl Document {
     }
 
     fn load_alias(&mut self, parser: &ParserInner, event: Event, ctx: &[i32]) -> Result<()> {
-        let EventData::Alias { anchor } = &event.data else {
-            unreachable!()
+        let anchor = match &event.data {
+            EventData::Alias { anchor } => anchor,
+            _ => unreachable!(),
         };
 
         for alias_data in &parser.aliases {
@@ -429,15 +432,15 @@ impl Document {
     }
 
     fn load_scalar(&mut self, parser: &mut ParserInner, event: Event, ctx: &[i32]) -> Result<()> {
-        let EventData::Scalar {
-            mut tag,
-            value,
-            style,
-            anchor,
-            ..
-        } = event.data
-        else {
-            unreachable!()
+        let (mut tag, value, style, anchor) = match event.data {
+            EventData::Scalar {
+                tag,
+                value,
+                style,
+                anchor,
+                ..
+            } => (tag, value, style, anchor),
+            _ => unreachable!(),
         };
 
         if tag.is_none() || tag.as_deref() == Some("!") {
@@ -461,14 +464,14 @@ impl Document {
         event: Event,
         ctx: &mut Vec<i32>,
     ) -> Result<()> {
-        let EventData::SequenceStart {
-            anchor,
-            mut tag,
-            style,
-            ..
-        } = event.data
-        else {
-            unreachable!()
+        let (anchor, mut tag, style) = match event.data {
+            EventData::SequenceStart {
+                anchor,
+                tag,
+                style,
+                ..
+            } => (anchor, tag, style),
+            _ => unreachable!(),
         };
 
         let mut items = Vec::with_capacity(16);
@@ -496,8 +499,9 @@ impl Document {
     }
 
     fn load_sequence_end(&mut self, event: Event, ctx: &mut Vec<i32>) -> Result<()> {
-        let Some(index) = ctx.last().copied() else {
-            panic!("sequence_end without a current sequence")
+        let index = match ctx.last().copied() {
+            Some(index) => index,
+            None => panic!("sequence_end without a current sequence"),
         };
         assert!(matches!(
             self.nodes[index as usize - 1].data,
@@ -514,14 +518,14 @@ impl Document {
         event: Event,
         ctx: &mut Vec<i32>,
     ) -> Result<()> {
-        let EventData::MappingStart {
-            anchor,
-            mut tag,
-            style,
-            ..
-        } = event.data
-        else {
-            unreachable!()
+        let (anchor, mut tag, style) = match event.data {
+            EventData::MappingStart {
+                anchor,
+                tag,
+                style,
+                ..
+            } => (anchor, tag, style),
+            _ => unreachable!(),
         };
 
         let mut pairs = Vec::with_capacity(16);
@@ -547,8 +551,9 @@ impl Document {
     }
 
     fn load_mapping_end(&mut self, event: Event, ctx: &mut Vec<i32>) -> Result<()> {
-        let Some(index) = ctx.last().copied() else {
-            panic!("mapping_end without a current mapping")
+        let index = match ctx.last().copied() {
+            Some(index) => index,
+            None => panic!("mapping_end without a current mapping"),
         };
         assert!(matches!(
             self.nodes[index as usize - 1].data,
@@ -649,8 +654,9 @@ impl Document {
         let plain_implicit = node.tag.as_deref() == Some(DEFAULT_SCALAR_TAG);
         let quoted_implicit = node.tag.as_deref() == Some(DEFAULT_SCALAR_TAG); // TODO: Why compare twice?! (even the C code does this)
 
-        let NodeData::Scalar { value, style } = node.data else {
-            unreachable!()
+        let (value, style) = match node.data {
+            NodeData::Scalar { value, style } => (value, style),
+            _ => unreachable!(),
         };
         let event = Event::new(EventData::Scalar {
             anchor,
@@ -671,8 +677,9 @@ impl Document {
     ) -> Result<()> {
         let implicit = node.tag.as_deref() == Some(DEFAULT_SEQUENCE_TAG);
 
-        let NodeData::Sequence { items, style } = node.data else {
-            unreachable!()
+        let (items, style) = match node.data {
+            NodeData::Sequence { items, style } => (items, style),
+            _ => unreachable!(),
         };
         let event = Event::new(EventData::SequenceStart {
             anchor,
@@ -697,8 +704,9 @@ impl Document {
     ) -> Result<()> {
         let implicit = node.tag.as_deref() == Some(DEFAULT_MAPPING_TAG);
 
-        let NodeData::Mapping { pairs, style } = node.data else {
-            unreachable!()
+        let (pairs, style) = match node.data {
+            NodeData::Mapping { pairs, style } => (pairs, style),
+            _ => unreachable!(),
         };
         let event = Event::new(EventData::MappingStart {
             anchor,

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -818,13 +818,13 @@ impl<'w> Emitter<'w> {
     }
 
     fn emit_scalar(&mut self, event: &Event, analysis: &mut Analysis) -> Result<()> {
-        let Analysis {
-            anchor,
-            tag,
-            scalar: Some(scalar),
-        } = analysis
-        else {
-            unreachable!("no scalar analysis");
+        let (anchor, tag, scalar) = match analysis {
+            Analysis {
+                anchor,
+                tag,
+                scalar: Some(scalar),
+            } => (anchor, tag, scalar),
+            _ => unreachable!("no scalar analysis"),
         };
 
         self.select_scalar_style(event, scalar, tag)?;
@@ -842,8 +842,9 @@ impl<'w> Emitter<'w> {
         self.process_anchor(anchor.as_ref())?;
         self.process_tag(tag.as_ref())?;
 
-        let EventData::SequenceStart { style, .. } = &event.data else {
-            unreachable!()
+        let style = match &event.data {
+            EventData::SequenceStart { style, .. } => style,
+            _ => unreachable!(),
         };
 
         if self.flow_level != 0
@@ -863,8 +864,9 @@ impl<'w> Emitter<'w> {
         self.process_anchor(anchor.as_ref())?;
         self.process_tag(tag.as_ref())?;
 
-        let EventData::MappingStart { style, .. } = &event.data else {
-            unreachable!()
+        let style = match &event.data {
+            EventData::MappingStart { style, .. } => style,
+            _ => unreachable!(),
         };
 
         if self.flow_level != 0
@@ -916,8 +918,9 @@ impl<'w> Emitter<'w> {
                 length = analysis.anchor.as_ref().map_or(0, |a| a.anchor.len());
             }
             EventData::Scalar { .. } => {
-                let Some(scalar) = scalar else {
-                    panic!("no analysis for scalar")
+                let scalar = match scalar {
+                    Some(scalar) => scalar,
+                    None => panic!("no analysis for scalar"),
                 };
 
                 if scalar.multiline {
@@ -951,14 +954,14 @@ impl<'w> Emitter<'w> {
         scalar_analysis: &mut ScalarAnalysis,
         tag_analysis: &mut Option<TagAnalysis>,
     ) -> Result<()> {
-        let EventData::Scalar {
-            plain_implicit,
-            quoted_implicit,
-            style,
-            ..
-        } = &event.data
-        else {
-            unreachable!()
+        let (plain_implicit, quoted_implicit, style) = match &event.data {
+            EventData::Scalar {
+                plain_implicit,
+                quoted_implicit,
+                style,
+                ..
+            } => (plain_implicit, quoted_implicit, style),
+            _ => unreachable!(),
         };
 
         let mut style: ScalarStyle = *style;
@@ -1010,16 +1013,18 @@ impl<'w> Emitter<'w> {
     }
 
     fn process_anchor(&mut self, analysis: Option<&AnchorAnalysis>) -> Result<()> {
-        let Some(analysis) = analysis.as_ref() else {
-            return Ok(());
+        let analysis = match analysis.as_ref() {
+            Some(analysis) => analysis,
+            None => return Ok(()),
         };
         self.write_indicator(if analysis.alias { "*" } else { "&" }, true, false, false)?;
         self.write_anchor(analysis.anchor)
     }
 
     fn process_tag(&mut self, analysis: Option<&TagAnalysis>) -> Result<()> {
-        let Some(analysis) = analysis else {
-            return Ok(());
+        let analysis = match analysis {
+            Some(analysis) => analysis,
+            None => return Ok(()),
         };
 
         if analysis.handle.is_empty() && analysis.suffix.is_empty() {
@@ -1614,8 +1619,9 @@ impl<'w> Emitter<'w> {
                         let value_0 = ch as u32;
                         while k >= 0 {
                             let digit = (value_0 >> k) & 0x0F;
-                            let Some(digit_char) = char::from_digit(digit, 16) else {
-                                unreachable!("digit out of range")
+                            let digit_char = match char::from_digit(digit, 16) {
+                                Some(digit_char) => digit_char,
+                                None => unreachable!("digit out of range"),
                             };
                             // The libyaml emitter encodes unicode sequences as uppercase hex.
                             let digit_char = digit_char.to_ascii_uppercase();
@@ -1658,8 +1664,9 @@ impl<'w> Emitter<'w> {
 
         let first = string.chars().next();
         if is_space(first) || is_break(first) {
-            let Some(indent_hint) = char::from_digit(self.best_indent as u32, 10) else {
-                unreachable!("self.best_indent out of range")
+            let indent_hint = match char::from_digit(self.best_indent as u32, 10) {
+                Some(indent_hint) => indent_hint,
+                None => unreachable!("self.best_indent out of range"),
             };
             let mut indent_hint_buffer = [0u8; 1];
             let indent_hint = indent_hint.encode_utf8(&mut indent_hint_buffer);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -17,8 +17,9 @@ macro_rules! IS_ALPHA {
 }
 
 pub(crate) fn is_alpha(ch: impl Into<Option<char>>) -> bool {
-    let Some(ch) = ch.into() else {
-        return false;
+    let ch = match ch.into() {
+        Some(ch) => ch,
+        None => return false,
     };
     ch >= '0' && ch <= '9'
         || ch >= 'A' && ch <= 'Z'

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -130,8 +130,9 @@ fn read_utf8_char_unbuffered(
     reader.read_exact(&mut buffer[..width])?;
     if let Ok(valid) = core::str::from_utf8(&buffer[..width]) {
         // We read a whole, valid character.
-        let Some(ch) = valid.chars().next() else {
-            unreachable!()
+        let ch = match valid.chars().next() {
+            Some(ch) => ch,
+            None => unreachable!(),
         };
         push_char(out, ch, *offset)?;
         *offset += width;
@@ -158,7 +159,10 @@ fn read_utf16_buffered<const BIG_ENDIAN: bool>(
     };
 
     let chunks = available.chunks_exact(2).map(|chunk| {
-        let [a, b] = chunk else { unreachable!() };
+        let (a, b) = match chunk {
+            [a, b] => (a, b),
+            _ => unreachable!(),
+        };
         if BIG_ENDIAN {
             u16::from_be_bytes([*a, *b])
         } else {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -161,8 +161,9 @@ impl<R: BufRead> Scanner<R> {
 
     /// Equivalent to the libyaml macro `READ_LINE`.
     fn read_line_break(&mut self, string: &mut String) {
-        let Some(front) = self.buffer.front().copied() else {
-            panic!("unexpected end of input");
+        let front = match self.buffer.front().copied() {
+            Some(front) => front,
+            None => panic!("unexpected end of input"),
         };
 
         if let ('\r', Some('\n')) = (front, self.buffer.get(1).copied()) {

--- a/tests/data/Cargo.toml
+++ b/tests/data/Cargo.toml
@@ -19,5 +19,8 @@ flate2 = "=1.0.26"
 minreq = { version = "=2.6.0", features = ["https-native"] }
 native-tls = "=0.2.11"
 once_cell = "=1.18.0"
+# Pin OpenSSL versions for Rust 1.64.0 compatibility on Linux
+openssl = "=0.10.64"
+openssl-sys = "=0.9.101"
 security-framework-sys = "=2.9.1"
 tar = "0.4.16"

--- a/tests/data/Cargo.toml
+++ b/tests/data/Cargo.toml
@@ -10,11 +10,14 @@ path = "lib.rs"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
+proc-macro2 = "=1.0.60"
+quote = "=1.0.28"
 
 [build-dependencies]
 anyhow = "1.0"
-flate2 = "1.0"
-reqwest = { version = "0.11", features = ["blocking"] }
+flate2 = "=1.0.26"
+minreq = { version = "=2.6.0", features = ["https-native"] }
+native-tls = "=0.2.11"
+once_cell = "=1.18.0"
+security-framework-sys = "=2.9.1"
 tar = "0.4.16"

--- a/tests/data/build.rs
+++ b/tests/data/build.rs
@@ -20,8 +20,9 @@ fn main() {
 
 fn download_and_unpack() -> Result<()> {
     let url = format!("https://github.com/yaml/yaml-test-suite/archive/refs/tags/{TAG}.tar.gz");
-    let response = reqwest::blocking::get(url)?.error_for_status()?;
-    let decoder = GzDecoder::new(response);
+    let response = minreq::get(&url).send()?;
+    let bytes = response.as_bytes();
+    let decoder = GzDecoder::new(bytes);
     let mut archive = Archive::new(decoder);
     let prefix = format!("yaml-test-suite-{}", TAG);
 


### PR DESCRIPTION
I realise that you have recently bumped the Rust version and MSRV, however I would like to offer all serde_yaml users the ability to switch, and then increase the MSRV at an appropriate rate.  Then at least users wishing to have an old MSRV are stuck on an old version of a supported crate, rather than being stuck on an unsupported crate.

If you can accept this proposal, I am happy to follow up with some CI that ensures the declared MSRV is in fact supported, and PRs don't break that support unintentionally.