### PR TITLE
Made Scanner and Parser generic over the input stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 - Migrated to Rust Edition 2024 (MSRV 1.85).
+- `Scanner` and `Parser` are now generic over the input stream, instead of using dynamic
+  dispatch `dyn BufRead`. This allows the input to be owned by the parser using `std::io::Cursor`.
 
 ## 0.2.0 - 2025-11-26
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,7 +2,7 @@ use std::io::BufRead;
 
 use alloc::collections::VecDeque;
 
-use crate::{scanner::Scanner, Encoding, Error, Result};
+use crate::{Encoding, Error, Result, scanner::Scanner};
 
 const BOM_UTF8: [u8; 3] = [0xef, 0xbb, 0xbf];
 const BOM_UTF16LE: [u8; 2] = [0xff, 0xfe];
@@ -282,8 +282,11 @@ fn push_char(out: &mut VecDeque<char>, ch: char, offset: usize) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn yaml_parser_update_buffer(parser: &mut Scanner, length: usize) -> Result<()> {
-    let reader = parser.read_handler.as_deref_mut().expect("no read handler");
+pub(crate) fn yaml_parser_update_buffer<R: BufRead>(
+    parser: &mut Scanner<R>,
+    length: usize,
+) -> Result<()> {
+    let reader = parser.read_handler.as_mut().expect("no read handler");
     if parser.buffer.len() >= length {
         return Ok(());
     }


### PR DESCRIPTION
This allows the parser/scanner to own the input stream, which is sometimes more convenient. It also theoretically improves performance by avoiding dynamic dispatch in the hot path, but slightly hurts compilation time.

This also includes small changes that preserve internally allocated buffers on `reset()`.

Supersedes #12